### PR TITLE
Fix cross-platform native module fallback path

### DIFF
--- a/index.js
+++ b/index.js
@@ -26,7 +26,9 @@ function loadNative() {
   }
 
   // Fallback: try the unqualified name (useful during development)
-  const fallback = path.join(__dirname, 'target', 'release', 'libnative_iqa.dylib');
+  const ext = { darwin: '.dylib', linux: '.so', win32: '.dll' }[platform] ?? '.so';
+  const prefix = platform === 'win32' ? '' : 'lib';
+  const fallback = path.join(__dirname, 'target', 'release', `${prefix}native_iqa${ext}`);
   if (existsSync(fallback)) {
     return require(fallback);
   }


### PR DESCRIPTION
Closes #3

The fallback path in `loadNative()` was hardcoded to `.dylib` (macOS only). On Linux or Windows the fallback would silently miss, giving users a confusing error.

Now derives the correct filename per platform:
- macOS → `libnative_iqa.dylib`
- Linux → `libnative_iqa.so`
- Windows → `native_iqa.dll`